### PR TITLE
优化模型名称匹配逻辑，解决含大写字母的模型名称无法成功匹配的问题

### DIFF
--- a/SubtitleTranslate - ollama英译中.as
+++ b/SubtitleTranslate - ollama英译中.as
@@ -70,8 +70,6 @@ string ServerLogin(string User, string Pass) {
     selected_model = User.Trim();
     api_key = Pass.Trim();
 
-    selected_model.MakeLower();
-
     array<string> names = GetOllamaModelNames();
 
     // 验证模型名称是否为空或是否为支持的模型
@@ -85,9 +83,22 @@ string ServerLogin(string User, string Pass) {
         return "Ollama未返回有效的模型名称数据，请确认Ollama是否已运行或已有下载的模型。Ollama did not return valid model name data. Please confirm whether Ollama is running or has any downloaded models.";
     }
     bool matched = false;
+
+    // 创建一个用户输入的小写副本用于比较
+    string user_input_lower = selected_model;
+    user_input_lower.MakeLower();
+
     for (int i = 0; i < modelscount; i++){
-        if (selected_model == names[i]){
+        // 创建一个列表中模型名称的小写副本用于比较
+        string current_model_name = names[i];
+        string current_model_lower = current_model_name;
+        current_model_lower.MakeLower();
+
+        // 进行不区分大小写的比较
+        if (user_input_lower == current_model_lower){
             matched = true;
+            // 将 selected_model 更新为列表中准确的大小写名称，确保 API 调用正确
+            selected_model = current_model_name; 
             break;
         }
     }

--- a/SubtitleTranslate - ollama英译中.as
+++ b/SubtitleTranslate - ollama英译中.as
@@ -39,6 +39,7 @@ string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)";
 string api_url = "http://127.0.0.1:11434/api/chat"; // 使用本地原生API地址
 string api_url_base = "http://127.0.0.1:11434";
 string context = "";
+bool startup_login = false; // 标记是否为 PotPlayer 启动时的自动登录
 
 // 支持的语言列表
 array<string> LangTable = 
@@ -70,6 +71,14 @@ string ServerLogin(string User, string Pass) {
     selected_model = User.Trim();
     api_key = Pass.Trim();
 
+    // 如果是 PotPlayer 启动时的自动登录，跳过模型验证，直接保存
+    if (startup_login) {
+        startup_login = false; // 重置标志
+        HostSaveString("api_key_ollama", api_key);
+        HostSaveString("selected_model_ollama", selected_model);
+        return "200 ok";
+    }
+    // 用户手动点击确定时，执行完整的模型验证
     array<string> names = GetOllamaModelNames();
 
     // 验证模型名称是否为空或是否为支持的模型
@@ -205,6 +214,7 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
 
 // 插件初始化
 void OnInitialize() {
+    startup_login = true; // 标记为 PotPlayer 启动时的自动登录
     HostPrintUTF8("{$CP949=ollama 번역 플러그인이 로드되었습니다.$}{$CP950=ollama 翻譯插件已加載。$}{$CP0=ollama translation plugin loaded.$}\n");
     // 从临时存储中加载模型名称和 API Key（如果已保存），使用新的键名
     api_key = HostLoadString("api_key_ollama", "");

--- a/SubtitleTranslate - ollama英译中.as
+++ b/SubtitleTranslate - ollama英译中.as
@@ -36,7 +36,7 @@ string DEFAULT_MODEL_NAME = "wangshenzhi/gemma2-9b-chinese-chat:latest";
 string api_key = "";
 string selected_model = DEFAULT_MODEL_NAME; // 默认使用第一个模型
 string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)";
-string api_url = "http://127.0.0.1:11434/v1/chat/completions"; // 新增本地API地址
+string api_url = "http://127.0.0.1:11434/api/chat"; // 使用本地原生API地址
 string api_url_base = "http://127.0.0.1:11434";
 string context = "";
 
@@ -170,7 +170,7 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
     string escapedPrompt = JsonEscape(prompt);
 
     // 构建请求数据
-    string requestData = "{\"model\":\"" + selected_model + "\",\"messages\":[{\"role\":\"user\",\"content\":\"" + escapedPrompt + "\"}]}";
+    string requestData = "{\"model\":\"" + selected_model + "\",\"messages\":[{\"role\":\"user\",\"content\":\"" + escapedPrompt + "\"}],\"stream\":false,\"think\":false}";
     string headers = "Content-Type: application/json";
 
     // 发送请求
@@ -188,9 +188,9 @@ string Translate(string Text, string &in SrcLang, string &in DstLang) {
         return "";
     }
 
-    JsonValue choices = Root["choices"];
-    if (choices.isArray() && choices[0]["message"]["content"].isString()) {
-        string translatedText = choices[0]["message"]["content"].asString();
+    JsonValue message = Root["message"];
+    if (message.isObject() && message["content"].isString()) {
+        string translatedText = message["content"].asString();
         if (DstLang == "fa" || DstLang == "ar" || DstLang == "he") {
             translatedText = UNICODE_RLE + translatedText;
         }


### PR DESCRIPTION
修改 ServerLogin 函数，删除强制转小写的代码，并改为不区分大小写进行比对，比对成功后将模型名称修正为 Ollama 列表中的准确名称。